### PR TITLE
Restore button outline

### DIFF
--- a/src/components/save-button.tsx
+++ b/src/components/save-button.tsx
@@ -14,7 +14,6 @@ const ButtonContainer = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  outline: none;
   min-width: 86px;
   height: 32px;
   border-radius: 5px;

--- a/src/components/vcr-button.tsx
+++ b/src/components/vcr-button.tsx
@@ -23,7 +23,6 @@ const ButtonContainer = styled.button`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  outline: none;
   border: none;
   min-width: 60px;
   height: 74px;


### PR DESCRIPTION
This small PR restores the button outline on the VCR and Save buttons to allow keyboard only accessible use of the controls (button highlight shows when tabbing between buttons to indicate focused button).